### PR TITLE
Bootstrap3 : Correcting extends and checkbox class

### DIFF
--- a/Resources/views/Twitter/form_bootstrap3_layout.html.twig
+++ b/Resources/views/Twitter/form_bootstrap3_layout.html.twig
@@ -1,7 +1,7 @@
-{% extends 'ZenstruckFormBundle:Twitter:form_bootstrap_layout.html.twig' %}
+{% extends 'form_div_layout.html.twig' %}
 
 {% block widget_attributes %}
-    {% if type is not defined or (type is defined and type != 'hidden') %}
+    {% if type is defined and type != 'hidden' %}
         {% set attr = attr|merge({'class': (attr.class|default('') ~ ' form-control')|trim}) %}
     {% endif %}
 


### PR DESCRIPTION
Make the bootstrap3 form theme extend of symfony form_div_layout instead of botstrap 2 one + update for avoiding checkbox to get the form-control class.

I don't know if this modification has some side effect on other field but for me it's working.
