### PR TITLE
Adding type form select field to have them the from-control class

### DIFF
--- a/Resources/views/Twitter/form_bootstrap3_layout.html.twig
+++ b/Resources/views/Twitter/form_bootstrap3_layout.html.twig
@@ -10,7 +10,7 @@
 
 {% block form_row %}
     {% spaceless %}
-        <div class="form-group {% if errors|length > 0 %}has-error{% endif %}">
+        <div class="form-group{% if errors|length > 0 %} has-error{% endif %}">
             {{ form_label(form, label|default(null)) }}
             {% set ctrl_width = theme_options.control_width is defined ? theme_options.control_width : 'col-md-10' %}
             <div class="{{ ctrl_width }}">


### PR DESCRIPTION
With my previous PR select field don't get the `form-control` class as they don't have their type setted in a variable.
