### PR TITLE
Fixing form error pluralization.

### DIFF
--- a/Resources/views/Twitter/form_bootstrap3_layout.html.twig
+++ b/Resources/views/Twitter/form_bootstrap3_layout.html.twig
@@ -135,7 +135,11 @@
         {% if errors|length > 0 %}
             <span class="help-block">
                 {% for error in errors %}
-                    {{ error.messageTemplate|trans(error.messageParameters, 'validators') }}
+                    {% if error.messagePluralization > 1 %}
+                        {{ error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'validators') }}
+                    {% else %}
+                        {{ error.messageTemplate|trans(error.messageParameters, 'validators') }}
+                    {% endif %}
                 {% endfor %}
             </span>
         {% endif %}

--- a/Resources/views/Twitter/form_bootstrap_layout.html.twig
+++ b/Resources/views/Twitter/form_bootstrap_layout.html.twig
@@ -118,7 +118,11 @@
         {% if errors|length > 0 %}
             <span class="help-inline">
                 {% for error in errors %}
-                    {{ error.messageTemplate|trans(error.messageParameters, 'validators') }}
+                    {% if error.messagePluralization > 1 %}
+                        {{ error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'validators') }}
+                    {% else %}
+                        {{ error.messageTemplate|trans(error.messageParameters, 'validators') }}
+                    {% endif %}
                 {% endfor %}
             </span>
         {% endif %}


### PR DESCRIPTION
Form validators using pluralized translations aren't translated properly.

I've no idea if it's the correct way to fix it but it works for me.
