### PR TITLE
Add form-control class on textarea form field

### DIFF
--- a/Resources/views/Twitter/form_bootstrap3_layout.html.twig
+++ b/Resources/views/Twitter/form_bootstrap3_layout.html.twig
@@ -163,3 +163,8 @@
         </div>
     {% endspaceless %}
 {% endblock %}
+
+{% block textarea_widget -%}
+    {% set type = 'textarea' %}
+    {{ parent() }}
+{%- endblock textarea_widget %}


### PR DESCRIPTION
Without it the textarea doesn't get apply the `form-control` bootstrap class.
Or maybe I'm missing something.