### PR TITLE
Added icon option for ajax entity dropdown result items

### DIFF
--- a/Resources/public/js/helper.js
+++ b/Resources/public/js/helper.js
@@ -101,11 +101,22 @@ var ZenstruckFormHelper = {
         var entity = $element.data('entity');
         var minimumInputLength = $element.data('minimum-input-length');
         var extraData = $element.data('extra-data');
+        // Add icon in result items template
+        var formatResult = function(result, container, query, escapeMarkup) {
+            var markup=[];
+            if (result.icon) {
+                markup.push(result.icon+" ");
+            }
+            window.Select2.util.markMatch(result.text, query.term, markup, escapeMarkup);
+
+            return markup.join("");
+        };
 
         var options = {
             minimumInputLength: minimumInputLength,
             allowClear: !required,
             multiple: multiple,
+            formatResult: formatResult,
             placeholder: function(element) {
                 return $(element).data('placeholder');
             },


### PR DESCRIPTION
Gives the possibility to developer to add icon option in result items in order to add a small icon before the result text. Example of result item: 

``` javascript
{
   id: "1", 
   text: "item 1", 
   icon: "<img src='/path/to/image'/>"
}
```

This way a fontawesome icon can also be added using `<i class="fa fa-class"></i>` as the icon attribute.
